### PR TITLE
[#31] fixed build dependency of main projects ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,4 @@ modules.xml
 
 # Sonarlint plugin
 .idea/sonarlint
+/.metadata/

--- a/NbAsm/pom.xml
+++ b/NbAsm/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>NoBeardProject</artifactId>
-            <version>${project.version}</version>
+            <version>2.0.1</version>
         </dependency>
     </dependencies>
 

--- a/NbM/pom.xml
+++ b/NbM/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>NoBeardProject</artifactId>
-            <version>${project.version}</version>
+            <version>2.0.1</version>
         </dependency>
     </dependencies>
 

--- a/Nbc/pom.xml
+++ b/Nbc/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>NoBeardProject</artifactId>
-            <version>${project.version}</version>
+            <version>2.0.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
… to NoBeard project by replacing '${project.version}' with hardcoded version (2.0.1) of the NoBeardProject into relevant pom.xmls. Maybe a shared variable for the base project version  or a shared version for all projects is more suitable.